### PR TITLE
Fix markdown-macros with new markdown

### DIFF
--- a/mdx_macros/__init__.py
+++ b/mdx_macros/__init__.py
@@ -49,9 +49,7 @@ class MacroExtension(markdown.Extension):
     def __init__(self, config):
         # set extension defaults
         self.config = {'macros': []}
-        
-        for conf in config:
-            self.config[conf[0]] = conf[1]
+        self.config.update(config)
 
     def extendMarkdown(self, md, md_globals):
         macroPattern = MacroPattern(MACRO_RE, self.config)
@@ -103,5 +101,9 @@ class MacroBlockParser(markdown.blockprocessors.BlockProcessor):
                 elem.text = block
                 logging.error("Invalid macro: %s" % macro_name)
         
-def makeExtension(config=[]):
+def makeExtension(configItems=None, **configDict):
+    # old markdown passes the config as a list of pairs as the first positional
+    # argument, new markdown passes the config as kwargs.
+    config = {}
+    config.update(configItems or [], **configDict)
     return MacroExtension(config)


### PR DESCRIPTION
Currently, `markdown-macros` is broken under `markdown >= 2.5.0` when adding extensions via macro name rather than instance. `example.py` exhibits this bug. This pull request fixes the issue, and `example.py` now runs fine with `markdown == 2.4`, `markdown == 2.5` and `markdown == 2.6.7` (the latest at the time of writing).
