### PR TITLE
Remove distribute dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     keywords="markdown macro macros",
     url="https://github.com/wnielson/markdown-macros",
     install_requires=[
-        "distribute",
         "Markdown>=2.1.1"
     ],
 )


### PR DESCRIPTION
This dependency isn't necessary, and breaks installation on Python 3.