### PR TITLE
Fix usage on recent versions of Markdown

### DIFF
--- a/example.py
+++ b/example.py
@@ -42,4 +42,4 @@ is the sum of 19923+19875 as a block-level element:
 [[Sum(19923, 19875)]]
 """
 
-print md.convert(text)
+print(md.convert(text))

--- a/mdx_macros/__init__.py
+++ b/mdx_macros/__init__.py
@@ -46,10 +46,10 @@ class MacroExtension(markdown.Extension):
     """
     Macro Extension for Python-Markdown.
     """
-    def __init__(self, config):
+    def __init__(self, **kwargs):
         # set extension defaults
         self.config = {'macros': []}
-        self.config.update(config)
+        self.config.update(kwargs)
 
     def extendMarkdown(self, md, md_globals):
         macroPattern = MacroPattern(MACRO_RE, self.config)
@@ -101,9 +101,9 @@ class MacroBlockParser(markdown.blockprocessors.BlockProcessor):
                 elem.text = block
                 logging.error("Invalid macro: %s" % macro_name)
         
-def makeExtension(configItems=None, **configDict):
+def makeExtension(*args, **kwargs):
     # old markdown passes the config as a list of pairs as the first positional
     # argument, new markdown passes the config as kwargs.
-    config = {}
-    config.update(configItems or [], **configDict)
-    return MacroExtension(config)
+    for arg in args:
+        kwargs.update(arg)
+    return MacroExtension(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,7 @@ setup(
     install_requires=[
         "Markdown>=2.1.1"
     ],
+    entry_points={
+        "markdown.extensions": ["macros = mdx_macros:MacroExtension"]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name="markdown-macros",
     version="0.1.3",
-    packages=find_packages(),
+    packages=["mdx_macros"],
     author="Weston Nielson",
     author_email="wnielson@github",
     description="An extension for python-markdown that add Trac-like macro support.",
@@ -16,4 +16,6 @@ setup(
     entry_points={
         "markdown.extensions": ["macros = mdx_macros:MacroExtension"]
     },
+    tests_require=["nose"],
+    test_suite="nose.collector",
 )

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,16 @@
+import markdown
+import mdx_macros
+
+
+class DummyMacro(mdx_macros.BaseMacro):
+    pass
+
+
+def test_entry_with_literal():
+    markdown.Markdown(extensions=[mdx_macros.MacroExtension(macros=[DummyMacro])])
+
+
+def test_entry_with_string():
+    markdown.Markdown(
+        extensions=["macros"], config={"macros": {"macros": [DummyMacro]}},
+    )


### PR DESCRIPTION
This fixes usage of `markdown-macros` with new versions of `markdown` and Python. Now, on any version of `markdown` from 2.1.1 to 3.2.1 (the latest), and Python 2 or 3, the extension can be used how extensions are supposed to be.